### PR TITLE
Move credentials to env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+USER_ID=
+USER_HASH=

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A small [Next.js](https://nextjs.org/) application that fetches hero data from t
    ```bash
    npm install
    ```
-2. (Optional) Update the `USER_ID` and `USER_HASH` constants in `utils/getHeroes.ts` with your own credentials.
+2. Create a `.env.local` file and set `USER_ID` and `USER_HASH` to your credentials.
 3. Run the development server
    ```bash
    npm run dev
@@ -37,6 +37,11 @@ Run ESLint with:
 ```bash
 npm run lint
 ```
+
+## Deployment
+
+Deploy the app to Vercel and configure your custom domain, e.g.
+`idle-champions-ivory.vercel.app`, in the Vercel project settings.
 
 ## Notes
 

--- a/utils/getHeroes.ts
+++ b/utils/getHeroes.ts
@@ -1,7 +1,7 @@
 import type { Hero, Seat } from "../types/heroes";
 
-const USER_ID = 99543;
-const USER_HASH = "8843f90c49fe1d028ecd93c3a6f610f4";
+const USER_ID = process.env.USER_ID ?? "";
+const USER_HASH = process.env.USER_HASH ?? "";
 
 // https://ps22.idlechampions.com/~idledragons/post.php?call=getuserdetails&instance_key=1&mobile_client_version=547&user_id=99543&hash=8843f90c49fe1d028ecd93c3a6f610f4
 // https://ps22.idlechampions.com/~idledragons/post.php?call=getcampaigndetails&game_instance_id=1&instance_id=1&mobile_client_version=547&user_id=99543&hash=8843f90c49fe1d028ecd93c3a6f610f4


### PR DESCRIPTION
## Summary
- move API credentials to environment variables
- update README with env instructions, deployment info, and custom domain
- add `.env.example` template

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script)*
- `npm run build`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68896b60ca588326a3315d3b8a6c3ac4