### PR TITLE
Fix build crash when Idle Champions API unreachable

### DIFF
--- a/utils/getHeroes.ts
+++ b/utils/getHeroes.ts
@@ -39,7 +39,15 @@ export const getHeroes = async (): Promise<Hero[]> => {
     getUserDetails(),
   ]);
 
-  if (!definitions || !userDetails) {
+  // Ensure both API calls returned the expected data structure
+  if (
+    !definitions ||
+    !definitions.hero_defines ||
+    !userDetails ||
+    !userDetails.details ||
+    !Array.isArray(userDetails.details.game_instances) ||
+    !Array.isArray(userDetails.details.heroes)
+  ) {
     return [];
   }
 


### PR DESCRIPTION
## Summary
- guard against missing data from Idle Champions API

## Testing
- `npm run lint`
- `npm run build`
- `npm run type-check` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68899853035483269cc38a1bf291f0cb