### PR TITLE
docs: fix colour‑coded typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Idle Champions Seat Viewer
 
-A small [Next.js](https://nextjs.org/) application that fetches hero data from the Idle Champions API and displays champions grouped by their seat. Heroes are colour coded based on whether you own them and if they are currently in a formation.
+A small [Next.js](https://nextjs.org/) application that fetches hero data from the Idle Champions API and displays champions grouped by their seat. Heroes are colour‐coded based on whether you own them and if they are currently in a formation.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- fix typo "colour coded" -> "colour‑coded"

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889d4b457d08326af542795fb6b5f01