### PR TITLE
Fix env variable fetch on Vercel

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,8 @@
 import { getHeroes, parseSeats } from "../utils/getHeroes";
 
+// Force dynamic rendering so data is fetched on every request.
+export const dynamic = "force-dynamic";
+
 import styles from "./page.module.css";
 
 // https://ps22.idlechampions.com/~idledragons/post.php?call=getuserdetails&instance_key=1&mobile_client_version=547&user_id=99543&hash=8843f90c49fe1d028ecd93c3a6f610f4

--- a/utils/getHeroes.ts
+++ b/utils/getHeroes.ts
@@ -10,7 +10,8 @@ const USER_HASH = process.env.USER_HASH ?? "";
 
 const safeFetchJson = async (url: string) => {
   try {
-    const res = await fetch(url);
+    // Disable Next.js fetch caching so data is retrieved at request time.
+    const res = await fetch(url, { cache: "no-store" });
     if (!res.ok) {
       throw new Error(`Request failed with status ${res.status}`);
     }


### PR DESCRIPTION
## Summary
- disable Next.js fetch caching so data loads at request time
- mark page as dynamic to ensure runtime environment variables are used

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a57f572488326b57af52678f8a2e2